### PR TITLE
ni already used in rfc8529#section-6

### DIFF
--- a/ietf-network-inventory.yang
+++ b/ietf-network-inventory.yang
@@ -1,7 +1,7 @@
 module ietf-network-inventory {
   yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-network-inventory";
-  prefix ni;
+  prefix nwi;
 
   import iana-hardware {
     prefix ianahw;
@@ -91,7 +91,7 @@ module ietf-network-inventory {
   }
 
   identity ne-physical {
-    base ni:ne-type;
+    base nwi:ne-type;
     description
       "A physical network element (NE). ";
   }


### PR DESCRIPTION
Replace 'ni' prefix with 'nwi': fix #59 