### PR TITLE
Clean-up YANG groupings and components identifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ draft-y3bp-network-inventory-yang.xml
 package-lock.json
 report.xml
 !requirements.txt
+*.bash

--- a/draft-ietf-ivy-network-inventory-yang.md
+++ b/draft-ietf-ivy-network-inventory-yang.md
@@ -446,7 +446,7 @@ The hierarchical components' identifier could be found by the "component-referen
 
 ### Component-Specific Info Design
 
-According to the management requirements from operators, some important attributes are not defined in {{!RFC8348}}. These attributes could be component-specific and are not suitable to define under the component list node. So, component-specific attributes can be defined by augmenting the component-specific info containers for the attributes applicable to HW e.g. boards/slot components only. Other component-specific attributes, such as SW-specific-info, may be defined in companion augmentation data models, such as
+According to the management requirements from operators, some important attributes are not defined in {{!RFC8348}}. These attributes could be component-specific and are not suitable to be defined under the component list node. Instead, they can be defined by augmenting the component-specific info container for the attributes applicable to HW e.g. boards/slot components only. Other component-specific attributes, such as SW-specific-info, may be defined in companion augmentation data models, such as
 {{?I-D.wzwb-ivy-network-inventory-software}} and are out of the scope of this model.
 
 ~~~~ ascii-art

--- a/draft-ietf-ivy-network-inventory-yang.md
+++ b/draft-ietf-ivy-network-inventory-yang.md
@@ -298,7 +298,7 @@ However, the YANG data model defined in {{!RFC8348}} has been used as a referenc
               ......................................
 ~~~~
 
-## Common Design for All Inventory Objects
+## Common Design for All Inventory Objects {#common-attributes}
 
 For all the inventory objects, there are some common attributes existing. Such as:
 
@@ -475,7 +475,7 @@ The hierarchical components' identifier could be found by the "component-referen
 
 ### Component-Specific Info Design
 
-According to the management requirements from operators, some important attributes are not defined in {{!RFC8348}}. These attributes could be component-specific and are not suitable to define under the component list node. So, the model can be augmented with HW-specific-info grouping containing attributes applicable to HW e.g. boards/slot components only. Other component-specific attributes, such as SW-specific-info, may be defined in companion augmentation data models, such as
+According to the management requirements from operators, some important attributes are not defined in {{!RFC8348}}. These attributes could be component-specific and are not suitable to define under the component list node. So, component-specific attributes can be defined by augmenting the component-specific info containers for the attributes applicable to HW e.g. boards/slot components only. Other component-specific attributes, such as SW-specific-info, may be defined in companion augmentation data models, such as
 {{?I-D.wzwb-ivy-network-inventory-software}} and are out of the scope of this model.
 
 ~~~~ ascii-art
@@ -495,11 +495,19 @@ According to the description in {{!RFC8348}}, the attribute named "model-name" u
 
 ~~~~ ascii-art
   +--ro components
-     +--ro component* [uuid]
+     +--ro component* [component-id]
         ...................................
         +--ro part-number?           string
         ...................................
 ~~~~
+
+### Component identifiers
+
+There are some use cases where the name of the components are assigned and changed by the operator. In these cases, the assigned names are also not guaranteed to be always unique.
+
+In order to support these use cases, this model is not aligned with {{!RFC8348}} in defining the component name as the key for the component list.
+
+Instead the name is defined as an optional attribute and the component-id is defined as the key for the component list (in alignment with the approach followed for the network-element list).
 
 {: #ni-augment}
 

--- a/ietf-network-inventory.tree
+++ b/ietf-network-inventory.tree
@@ -23,20 +23,20 @@ module: ietf-network-inventory
                  +--rw name?                    string
                  +--rw description?             string
                  +--rw alias?                   string
+                 +--ro hardware-rev?            string
+                 +--ro software-rev?            string
+                 +--ro software-patch-rev*      string
+                 +--ro mfg-name?                string
+                 +--ro mfg-date?                yang:date-and-time
+                 +--ro serial-number?           string
+                 +--ro product-name?            string
+                 +--ro firmware-rev?            string
+                 +--ro part-number?             string
+                 +--ro asset-id?                string
                  +--ro child-component-ref
                  +--ro parent-rel-pos?          int32
                  +--ro parent-component-ref
-                 +--ro hardware-rev?            string
-                 +--ro firmware-rev?            string
-                 +--ro software-rev?            string
-                 +--ro software-patch-rev*      string
-                 +--ro serial-num?              string
-                 +--ro mfg-name?                string
-                 +--ro part-number?             string
-                 +--ro product-name?            string
-                 +--ro asset-id?                string
                  +--ro is-fru?                  boolean
-                 +--ro mfg-date?                yang:date-and-time
                  +--ro uri*                     inet:uri
                  +--ro chassis-specific-info
                  +--ro slot-specific-info

--- a/ietf-network-inventory.yang
+++ b/ietf-network-inventory.yang
@@ -108,7 +108,7 @@ module ietf-network-inventory {
       type yang:uuid;
       config false;
       description
-        "The Universallu Unique Identifier of the entity
+        "The Universally Unique Identifier of the entity
          (e.g., component).";
     }
     leaf name {

--- a/ietf-network-inventory.yang
+++ b/ietf-network-inventory.yang
@@ -70,7 +70,7 @@ module ietf-network-inventory {
   // RFC Ed.: update the date below with the date of RFC publication
   // and remove this note.
 
-  revision 2024-04-09 {
+  revision 2024-04-30 {
     description
       "Initial version";
     reference
@@ -78,6 +78,10 @@ module ietf-network-inventory {
     //RFC Editor: replace XXXX with actual RFC number, update date
     //information and remove this note
   }
+
+  /*
+   * Identities
+   */
 
   identity non-hardware-component-class {
     description
@@ -90,11 +94,15 @@ module ietf-network-inventory {
       "Base identity for network element (NE) types.";
   }
 
-  identity ne-physical {
-    base nwi:ne-type;
-    description
-      "A physical network element (NE). ";
-  }
+    identity ne-physical {
+      base nwi:ne-type;
+      description
+        "A physical network element (NE). ";
+    }
+
+  /*
+   * Groupings
+   */
 
   grouping common-entity-attributes {
     description
@@ -129,11 +137,6 @@ module ietf-network-inventory {
         "a alias name of inventory objects. This alias name can be
          specified by network manager.";
     }
-  }
-
-  grouping ne-specific-info-grouping {
-    description
-      "Attributes applicable to network elements.";
     leaf hardware-rev {
       type string;
       config false;
@@ -185,71 +188,13 @@ module ietf-network-inventory {
     }
   }
 
-  grouping component-specific-info-grouping {
-    description
-      "Provide component-specific attributes for different
-       components.";
-    container chassis-specific-info {
-      when "../class = 'ianahw:chassis'";
-      config false;
-      description
-        "This container contains some attributes belong to
-         chassis only.";
-      uses chassis-specific-info-grouping;
-    }
-    container slot-specific-info {
-      when "../class = 'ianahw:container'";
-      config false;
-      description
-        "This container contains some attributes belong to
-         slot only.";
-      uses slot-specific-info-grouping;
-    }
-    container board-specific-info {
-      when "../class = 'ianahw:module'";
-      config false;
-      description
-        "This container contains some attributes belong to
-         board only.";
-      uses board-specific-info-grouping;
-    }
-    container port-specific-info {
-      when "../class = 'ianahw:port'";
-      config false;
-      description
-        "This container contains some attributes belong to
-         port only.";
-      uses port-specific-info-grouping;
-    }
-  }
+  /* 
+   * Data Nodes
+   */
 
-  grouping chassis-specific-info-grouping {
-    //To be enriched in the future.
+  container network-inventory {
     description
-      "Specific attributes applicable to chassis only.";
-  }
-
-  grouping slot-specific-info-grouping {
-    //To be enriched in the future.
-    description
-      "Specific attributes applicable to slots only.";
-  }
-
-  grouping board-specific-info-grouping {
-    //To be enriched in the future.
-    description
-      "Specific attributes applicable to boards only.";
-  }
-
-  grouping port-specific-info-grouping {
-    //To be enriched in the future.
-    description
-      "Specific attributes applicable to ports only.";
-  }
-
-  grouping ne-info-grouping {
-    description
-      "Grouping for network elements.";
+      "Top-level container for network inventory.";
     container network-elements {
       description
         "The top-level container for the list of network elements
@@ -273,7 +218,6 @@ module ietf-network-inventory {
             "The type of network element (NE).";
         }
         uses common-entity-attributes;
-        uses ne-specific-info-grouping;
         container components {
           description
             "The top-level container for the list of components
@@ -301,7 +245,111 @@ module ietf-network-inventory {
               description
                 "The type of the component.";
             }
-            uses common-entity-attributes;
+            uses common-entity-attributes {
+              refine hardware-rev {
+                description
+                  "The vendor-specific hardware revision string for
+                  the component. The preferred value is the hardware
+                  revision identifier actually printed on the
+                  component itself (if present).";
+                reference
+                  "RFC 6933: Entity MIB (Version 4) -
+                            entPhysicalHardwareRev";
+              }
+              refine software-rev {
+                description
+                  "The vendor-specific software revision string for
+                  the component.";
+                reference
+                  "RFC 6933: Entity MIB (Version 4) -
+                            entPhysicalSoftwareRev";
+              }
+              refine software-patch-rev {
+                description
+                  "The vendor-specific patch software revision string
+                  for the component.";
+              }
+              refine mfg-name {
+                description
+                  "The name of the manufacturer of this physical
+                  component.
+                  The preferred value is the manufacturer name string
+                  actually printed on the component itself
+                  (if present).
+
+                  Note that comparisons between instances of the
+                  'model-name', 'firmware-rev', 'software-rev', and
+                  'serial-number' nodes are only meaningful amongst
+                  components with the same value of 'mfg-name'.
+
+                  If the manufacturer name string associated with the
+                  physical component is unknown to the server, then
+                  this node is not instantiated.";
+                reference
+                  "RFC 6933: Entity MIB (Version 4) -
+                  entPhysicalMfgName";
+              }
+              refine mfg-date {
+                description
+                  "The date of manufacturing of the managed
+                  component.";
+                reference
+                  "RFC 6933: Entity MIB (Version 4) -
+                  entPhysicalMfgDate";
+              }
+              refine serial-number {
+                description
+                  "The vendor-specific serial number of the component
+                  instance. It is expected that vendors assign unique
+                  serial numbers to different component instances
+                  within the scope of the part number.";
+              }
+              refine product-name {
+              description
+                "The vendor-specific and human-interpretable string
+                 describing the component type. It is expected that
+                 vendors assign unique product names to different
+                 component types within the scope of the vendor.";
+              }
+            }
+            leaf firmware-rev {
+              type string;
+              config false;
+              description
+                "The vendor-specific firmware revision string for the
+                 component.";
+              reference
+                "RFC 6933: Entity MIB (Version 4) -
+                          entPhysicalFirmwareRev";
+            }
+            leaf part-number {
+              type string;
+              config false;
+              description
+                "The vendor-specific part number of the component
+                 type. It is expected that vendors assign unique part
+                 numbers to different component types within the
+                 scope of the vendor.";
+            }
+            leaf asset-id {
+              type string;
+              config false;
+              description
+                "This node is a user-assigned asset tracking
+                 identifier for the component.
+
+                 A server implementation MAY map this leaf to the
+                 entPhysicalAssetID MIB object.  Such an
+                 implementation needs to use some mechanism to handle
+                 the differences in size and characters allowed
+                 between this leaf and entPhysicalAssetID.
+                 
+                 The definition of such a mechanism is outside the
+                 scope of this document.";
+              reference
+                "RFC 6933: Entity MIB (Version 4) -
+                 entPhysicalAssetID";
+            }
             container child-component-ref {
               config false;
               description
@@ -331,113 +379,6 @@ module ietf-network-inventory {
                  parent-component-references container as in
                  draft-ietf-ccamp-network-inventory-yang-02.";
             }
-            leaf hardware-rev {
-              type string;
-              config false;
-              description
-                "The vendor-specific hardware revision string for the
-                 component.  The preferred value is the hardware
-                 revision identifier actually printed on the
-                 component itself (if present).";
-              reference
-                "RFC 6933: Entity MIB (Version 4) -
-                          entPhysicalHardwareRev";
-            }
-            leaf firmware-rev {
-              type string;
-              config false;
-              description
-                "The vendor-specific firmware revision string for the
-                 component.";
-              reference
-                "RFC 6933: Entity MIB (Version 4) -
-                          entPhysicalFirmwareRev";
-            }
-            leaf software-rev {
-              type string;
-              config false;
-              description
-                "The vendor-specific software revision string for the
-                 component.";
-              reference
-                "RFC 6933: Entity MIB (Version 4) -
-                          entPhysicalSoftwareRev";
-            }
-            leaf-list software-patch-rev {
-              type string;
-              config false;
-              description
-                "The vendor-specific patch software revision string
-                 for the component.";
-            }
-            leaf serial-num {
-              type string;
-              config false;
-              description
-                "The vendor-specific serial number of the component
-                 instance. It is expected that vendors assign unique
-                 serial numbers to different component instances
-                 within the scope of the part number.";
-            }
-            leaf mfg-name {
-              type string;
-              config false;
-              description
-                "The name of the manufacturer of this physical
-                 component.
-                 The preferred value is the manufacturer name string
-                 actually printed on the component itself
-                 (if present).
-
-                 Note that comparisons between instances of the
-                 'model-name', 'firmware-rev', 'software-rev', and
-                 'serial-num' nodes are only meaningful amongst
-                 components with the same value of 'mfg-name'.
-
-                 If the manufacturer name string associated with the
-                 physical component is unknown to the server, then
-                 this node is not instantiated.";
-              reference
-                "RFC 6933: Entity MIB (Version 4) -
-                 entPhysicalMfgName";
-            }
-            leaf part-number {
-              type string;
-              config false;
-              description
-                "The vendor-specific part number of the component
-                 type. It is expected that vendors assign unique part
-                 numbers to different component types within the
-                 scope of the vendor.";
-            }
-            leaf product-name {
-              type string;
-              config false;
-              description
-                "The vendor-specific and human-interpretable string
-                 describing the component type. It is expected that
-                 vendors assign unique product names to different
-                 component types within the scope of the vendor.";
-            }
-            leaf asset-id {
-              type string;
-              config false;
-              description
-                "This node is a user-assigned asset tracking
-                 identifier for the component.
-
-                 A server implementation MAY map this leaf to the
-                 entPhysicalAssetID MIB object.  Such an
-                 implementation needs to use some mechanism to handle
-                 the differences in size and characters allowed
-                 between this leaf and entPhysicalAssetID.
-                 
-                 The definition of such a mechanism is outside the
-                 scope of this document.";
-              reference
-                "RFC 6933: Entity MIB (Version 4) -
-                 entPhysicalAssetID";
-            }
             leaf is-fru {
               type boolean;
               config false;
@@ -453,16 +394,6 @@ module ietf-network-inventory {
                 "RFC 6933: Entity MIB (Version 4) -
                  entPhysicalIsFRU";
             }
-            leaf mfg-date {
-              type yang:date-and-time;
-              config false;
-              description
-                "The date of manufacturing of the managed
-                component.";
-              reference
-                "RFC 6933: Entity MIB (Version 4) -
-                 entPhysicalMfgDate";
-            }
             leaf-list uri {
               type inet:uri;
               config false;
@@ -472,16 +403,37 @@ module ietf-network-inventory {
               reference
                 "RFC 6933: Entity MIB (Version 4) - entPhysicalUris";
             }
-            uses component-specific-info-grouping;
+            container chassis-specific-info {
+              when "../class = 'ianahw:chassis'";
+              config false;
+              description
+                "This container contains some attributes belong to
+                chassis only.";
+            }
+            container slot-specific-info {
+              when "../class = 'ianahw:container'";
+              config false;
+              description
+                "This container contains some attributes belong to
+                slot only.";
+            }
+            container board-specific-info {
+              when "../class = 'ianahw:module'";
+              config false;
+              description
+                "This container contains some attributes belong to
+                board only.";
+            }
+            container port-specific-info {
+              when "../class = 'ianahw:port'";
+              config false;
+              description
+                "This container contains some attributes belong to
+                port only.";
+            }
           }
         }
       }
     }
-  }
-
-  container network-inventory {
-    description
-      "Top-level container for network inventory.";
-    uses ne-info-grouping;
   }
 }

--- a/ietf-network-inventory.yang
+++ b/ietf-network-inventory.yang
@@ -70,7 +70,7 @@ module ietf-network-inventory {
   // RFC Ed.: update the date below with the date of RFC publication
   // and remove this note.
 
-  revision 2024-04-30 {
+  revision 2024-09-30 {
     description
       "Initial version";
     reference
@@ -106,18 +106,19 @@ module ietf-network-inventory {
 
   grouping common-entity-attributes {
     description
-      "A set of attributes which are common to all the entities
-       (e.g., component, equipment room) defined in this module.";
+      "The set of attributes which are common to all the entities
+       (e.g., component, network elements) defined in this module.";
     leaf uuid {
       type yang:uuid;
       config false;
       description
-        "Uniquely identifies an entity (e.g., component).";
+        "The Universallu Unique Identifier of the entity
+         (e.g., component).";
     }
     leaf name {
       type string;
       description
-        "A name for an entity (e.g., component), as specified by
+        "The name of the  entity (e.g., component), as specified by
          a network manager, that provides a non-volatile 'handle'
          for the entity and that can be modified anytime during the
          entity lifetime.
@@ -129,62 +130,65 @@ module ietf-network-inventory {
     leaf description {
       type string;
       description
-        "a textual description of inventory object";
+        "The textual description of the entity (e.g., component).";
     }
     leaf alias {
       type string;
       description
-        "a alias name of inventory objects. This alias name can be
-         specified by network manager.";
+        "The alias name of the entity (e.g., component). This alias
+         name can be specified by network manager.";
     }
     leaf hardware-rev {
       type string;
       config false;
       description
-        "The vendor-specific hardware revision string for the NE.";
+        "The vendor-specific hardware revision string for the entity
+         (e.g., component).";
     }
     leaf software-rev {
       type string;
       config false;
       description
-        "The vendor-specific software revision string for the NE.";
+        "The vendor-specific software revision string for the entity
+         (e.g., component).";
     }
     leaf-list software-patch-rev {
       type string;
       config false;
       description
         "The vendor-specific patch software revision string for the
-         NE.";
+         entity (e.g., component).";
     }
     leaf mfg-name {
       type string;
       config false;
       description
-        "The name of the manufacturer of this NE";
+        "The name of the manufacturer of this entity
+         (e.g., component).";
     }
     leaf mfg-date {
       type yang:date-and-time;
       config false;
       description
-        "The date of manufacturing of the NE.";
+        "The date of manufacturing of the entity (e.g., component).";
     }
     leaf serial-number {
       type string;
       config false;
       description
-        "The vendor-specific serial number of the network element
-         instance. It is expected that vendors assign unique serial
-         numbers to different network element instances within the
-         scope of the product name.";
+        "The vendor-specific serial number of the the entity
+         (e.g., component) instace. It is expected that vendors
+         assign unique serial numbers to different network element
+         instances within the scope of the product name.";
     }
     leaf product-name {
       type string;
       config false;
       description
         "The vendor-specific and human-interpretable string
-         describing the network element type. It is expected that
-         vendors assign unique product names to different NE types
-         within the scope of the vendor.";
+         describing the entity (e.g., component) type. It is expected
+         that vendors assign unique product names to different entity
+         (e.g., component) types within the scope of the vendor.";
     }
   }
 
@@ -257,17 +261,9 @@ module ietf-network-inventory {
                             entPhysicalHardwareRev";
               }
               refine software-rev {
-                description
-                  "The vendor-specific software revision string for
-                  the component.";
                 reference
                   "RFC 6933: Entity MIB (Version 4) -
                             entPhysicalSoftwareRev";
-              }
-              refine software-patch-rev {
-                description
-                  "The vendor-specific patch software revision string
-                  for the component.";
               }
               refine mfg-name {
                 description
@@ -296,20 +292,6 @@ module ietf-network-inventory {
                 reference
                   "RFC 6933: Entity MIB (Version 4) -
                   entPhysicalMfgDate";
-              }
-              refine serial-number {
-                description
-                  "The vendor-specific serial number of the component
-                  instance. It is expected that vendors assign unique
-                  serial numbers to different component instances
-                  within the scope of the part number.";
-              }
-              refine product-name {
-              description
-                "The vendor-specific and human-interpretable string
-                 describing the component type. It is expected that
-                 vendors assign unique product names to different
-                 component types within the scope of the vendor.";
               }
             }
             leaf firmware-rev {

--- a/ietf-network-inventory.yang
+++ b/ietf-network-inventory.yang
@@ -173,7 +173,7 @@ module ietf-network-inventory {
       config false;
       description
         "The vendor-specific serial number of the the entity
-         (e.g., component) instace. It is expected that vendors
+         (e.g., component) instance. It is expected that vendors
          assign unique serial numbers to different network element
          instances within the scope of the product name.";
     }

--- a/ietf-network-inventory.yang
+++ b/ietf-network-inventory.yang
@@ -68,7 +68,7 @@ module ietf-network-inventory {
   // RFC Ed.: update the date below with the date of RFC publication
   // and remove this note.
 
-  revision 2024-09-30 {
+  revision 2024-10-02 {
     description
       "Initial version";
     reference
@@ -211,9 +211,9 @@ module ietf-network-inventory {
         }
         leaf ne-type {
           type identityref {
-            base ne-type;
+            base nwi:ne-type;
           }
-          default "physical";
+          default "nwi:ne-physical";
           config false;
           description
             "The NE type.";
@@ -335,7 +335,7 @@ module ietf-network-inventory {
               description
                 "A placeholder for adding the reference to child
                  component(s): to further discuss whether to define
-                 a child leaf-list as RFC8348 or a list of
+                 a child leaf-list as RFC 8348 or a list of
                  sub-components as openconfig-platform.";
             }
             leaf parent-rel-pos {
@@ -355,7 +355,7 @@ module ietf-network-inventory {
               description
                 "A placeholder for adding the reference to parent
                  component(s): to further discuss whether to define
-                 a parent attribute as RFC8348 or a
+                 a parent attribute as RFC 8348 or a
                  parent-component-references container as in
                  draft-ietf-ccamp-network-inventory-yang-02.";
             }
@@ -384,28 +384,30 @@ module ietf-network-inventory {
                 "RFC 6933: Entity MIB (Version 4) - entPhysicalUris";
             }
             container chassis-specific-info {
-              when "../class = 'ianahw:chassis'";
+              when "derived-from-or-self(../class, 
+                    'ianahw:chassis')";
               config false;
               description
                 "This container contains some attributes belong to
                 chassis only.";
             }
             container slot-specific-info {
-              when "../class = 'ianahw:container'";
+              when "derived-from-or-self(../class,
+                    'ianahw:container')";
               config false;
               description
                 "This container contains some attributes belong to
                 slot only.";
             }
             container board-specific-info {
-              when "../class = 'ianahw:module'";
+              when "derived-from-or-self(../class, 'ianahw:module')";
               config false;
               description
                 "This container contains some attributes belong to
                 board only.";
             }
             container port-specific-info {
-              when "../class = 'ianahw:port'";
+              when "derived-from-or-self(../class, 'ianahw:port')";
               config false;
               description
                 "This container contains some attributes belong to


### PR DESCRIPTION
Cleaned-up use of YANG groupings: fix #37
Added text clarifying the design choice for component identifier: fix #57 

---

Co-Authored-By: YuChaode <yuchaode@huawei.com>