### PR TITLE
Proposal for ports and breakouts modelling

### DIFF
--- a/draft-ietf-ivy-network-inventory-yang.md
+++ b/draft-ietf-ivy-network-inventory-yang.md
@@ -640,7 +640,7 @@ From a network inventory perspective, there is no need to distinguish between si
 Reporting whether an MPO port is configured as a trunk or as a breakout port, is outside the scope of the base network inventory model: the inventory topology mapping should instead provide sufficient information to identify how the MPO port is configured and, in case of breakout configuration, which channel is associated with which Link Termination Point (LTP).
 
 ~~~~ ascii-art
-{::include-fold JSON/ports-transceivers-breakouts-examples.json}
+{::include-fold json/ports-transceivers-breakouts-examples.json}
 ~~~~
 
 {: numbered="false"}

--- a/draft-ietf-ivy-network-inventory-yang.md
+++ b/draft-ietf-ivy-network-inventory-yang.md
@@ -237,7 +237,10 @@ Board/Card:
 : A pluggable equipment can be inserted into one or several slots (or sub-slots) and can afford a specific transmission function independently.
 
 Breakout Port:
-: A port is usually associated with a single physical interface. A breakout port is a port which is broken down and associated into multiple physical interfaces.
+: A port is usually associated with a single physical interface. A breakout port is a port which is broken down and associated into multiple physical interfaces. Those physical interfaces can have the same or different speeds and the same or different number of breakout channels.
+
+Trunk Port:
+: A trunk port is a port which is associated with one and only physical interface.
 
 Port Breakout:
 : The configuration of a breakout port.
@@ -484,7 +487,7 @@ The model defines the 'breakout-channels' presence container to indicate whether
 
 It is assumed that a port which supports port breakout can be configured either as a trunk port or as a breakout port.
 
-Reporting whether a port, which supports port breakout, is configured as a trunk or as a breakout port, is outside the scope of the base network inventory model: the model providing the mapping between the topology and the inventory models should instead provide sufficient information to identify how the port is configured and, in case of breakout configuration, which breakout channel is associated with which Link Termination Point (LTP), abstracting a device physical interface within the topology model.
+Reporting whether a port, which supports port breakout, is configured as a trunk or as a breakout port, is outside the scope of the base network inventory model. The model providing the mapping between the topology and the inventory models should provide sufficient information to identify how the port is configured and, in case of breakout configuration, which breakout channel is associated with which Link Termination Point (LTP), abstracting a device physical interface within the topology model.
 
 ## Changes Since RFC 8348
 

--- a/draft-ietf-ivy-network-inventory-yang.md
+++ b/draft-ietf-ivy-network-inventory-yang.md
@@ -621,6 +621,28 @@ An alternative YANG model structure, which defines the inventory objects directl
 
 The model proposed by this draft is designed to be as generic as possible so to cover future special types of inventory objects that could be used in other technologies, that have not been identified yet. If the inventory objects were to be defined directly with fixed hierarchical relationships in YANG model, this new type of inventory objects needs to be manually defined, which is not a backward compatible change and therefore is not an acceptable approach for implementation. With a generic model, it is only needed to augment a new component class and extend some specific attributes for this new inventory component class, which is more flexible. We consider that this generic data model, enabling a flexible and backward compatible approach for other technologies, represents the main scope of this draft. Solution description to efficiency/scalability limitations mentioned above is considered as out-of-scope.
 
+# JSON Examples
+
+This appendix contains an example of an instance data tree in JSON encoding {{?RFC7951}}.
+
+The example instantiates the "ietf-network-inventory" model to describe a single board with seven different types of ports, transceivers and breakouts configurations:
+
+1. An integrated port (non pluggable). This port can be of any type (e.g., optical or electrical), single-channel or multi-channel but not supporting breakouts;
+1. An empty port;
+1. A single channel optical pluggable port;
+1. A Wavelength-Division Multiplexing (WDM) based multi-channel optical port () which does not support breakouts: the four WDM channels are not reported since not relevant from inventory management perspective;
+1. A Multi-Fiber Push-on (MPO) trunk-only port. This type of MPO port does not support breakouts: the four WDM channels are not reported since not relevant from inventory management perspective;
+1. An MPO trunk port. This type of MPO port can support either the trunk or the breakout configuration but in this example, it is configured to support the trunk configuration: the four WDM channels are reported to support breakouts configuration, when needed.
+1. An MPO breakout port: the four WDM channels are reported to support breakouts configuration.
+
+From a network inventory perspective, there is no need to distinguish between single-channel and MPO trunk-only ports.
+
+Reporting whether an MPO port is configured as a trunk or as a breakout port, is outside the scope of the base network inventory model: the inventory topology mapping should instead provide sufficient information to identify how the MPO port is configured and, in case of breakout configuration, which channel is associated with which Link Termination Point (LTP).
+
+~~~~ ascii-art
+{::include-fold JSON/ports-transceivers-breakouts-examples.json}
+~~~~
+
 {: numbered="false"}
 
 # Acknowledgments

--- a/draft-ietf-ivy-network-inventory-yang.md
+++ b/draft-ietf-ivy-network-inventory-yang.md
@@ -136,7 +136,7 @@ Per the definition of {{?RFC8969}}, the network inventory model is a network mod
 This document defines one YANG module "ietf-network-inventory" in {{ni-yang}}.
 
 This base data model is application- and technology-agnostic (that is, valid for IP/MPLS, optical, and
-microwave networks in particular) and can be augmented to
+microwave networks as well as optical local loops, access networks, core networks, data centers, etc.) and can be augmented to
 include required application- and technology-specific inventory details together with specific hardware or software component's attributes.
 
 The YANG data model defined in the document is scoped to cover the common use cases for Network Inventory covering both hardware and base software information.
@@ -247,7 +247,7 @@ Port Breakout:
 Breakout channel:
 : An abstraction of the atomic resource elements into which a breakout port can be broken down: a physical interface can be associated with one or more breakout channels but no more than one physical interface can be associated with one breakout channel.
 : The physical elements abstracted as breakout channels are implementation specific.
-{{ports-transceivers-breakouts-examples}} provides some examples of breakout ports configurations and implementations.
+{{port-examples}} provides some examples of breakout ports configurations and implementations.
 
 Container:
 : A hardware component class that is capable of containing one or more removable physical entities (e.g., a slot in a chassis is containing a board).
@@ -270,7 +270,7 @@ The meanings of the symbols in the YANG tree diagrams are defined in {{?RFC8340}
 | yang   | ietf-yang-types                 | {{Section 3 of !RFC6991}}  |
 | ianahw | iana-hardware                   | {{IANA_HW_YANG}} |
 | nwi    | ietf-network-inventory          | RFC XXXX      |
-{: #tab-prefixes title="Prefixes and corresponding YANG modules"}
+{:#tab-prefixes title="Prefixes and corresponding YANG modules"}
 
 # YANG Data Model for Network Inventory Overview
 
@@ -318,7 +318,7 @@ However, the YANG data model defined in {{!RFC8348}} has been used as a referenc
               +--rw component-id            string
               ...
 ~~~~
-{: #fig-overall title="Overall Tree Structure"}
+{:#fig-overall title="Overall Tree Structure"}
 
 ## Common Design for All Inventory Objects {#common-attributes}
 
@@ -356,7 +356,7 @@ Description:
               +--rw class                   union
               ...
 ~~~~
-{: #fig-nec-tree title="Common Attributes Between Network Elements and Components Subtree"}
+{:#fig-nec-tree title="Common Attributes Between Network Elements and Components Subtree"}
 
 ## Network Element
 
@@ -377,7 +377,7 @@ elements as shown in {{fig-ne-tree}}.
         +--rw product-name?    string
         ...
 ~~~~
-{: #fig-ne-tree title="Network Elements Subtree"}
+{:#fig-ne-tree title="Network Elements Subtree"}
 
 > Not all the attributes defined in {{?RFC8348}} are applicable for network element. And there could also be some missing attributes which are not recognized by {{?RFC8348}}. More extensions could be introduced in later revisions after the missing attributes are fully discussed.
 
@@ -411,7 +411,7 @@ and non-hardware components (e.g., software components).
         +--rw mfg-date?               yang:date-and-time
         +--rw uri*                    inet:uri
 ~~~~
-{: #fig-comp-tree title="Components Subtree"}
+{:#fig-comp-tree title="Components Subtree"}
 
 For state data like "admin-state", "oper-state", and so on, this document considers that they are related to device hardware management, not network inventory. Therefore, they are outside of the scope of this document. Same for the sensor-data, they should be defined in some other performance monitoring data models instead of the inventory data model.
 
@@ -452,7 +452,7 @@ Based on TMF classification in {{TMF_SD2-20}}, hardware components can be divide
                                              |    port   |
                                              +-----------+
 ~~~~
-{: #fig-hw-inventory-object-relationship title="Relationship between typical inventory objects in physical network elements"}
+{:#fig-hw-inventory-object-relationship title="Relationship between typical inventory objects in physical network elements"}
 
 The "iana-hardware" module {{IANA_HW_YANG}} defines YANG identities for
 the hardware component types in the IANA-maintained "IANA-ENTITY-MIB"
@@ -477,6 +477,14 @@ The software components of other
 classes, such as platform software, BIOS, bootloader, and software
 patch information, are outside the scope of this document and defined other documents such as
 {{?I-D.wzwb-ivy-network-inventory-software}}.
+
+### Breakout ports {#ports}
+
+The model defines the 'breakout-channels' presence container to indicate whether the port, which contains the transceiver module, can be configured as a breakout port or not.
+
+It is assumed that a port which supports port breakout can be configured either as a trunk port or as a breakout port.
+
+Reporting whether a port, which supports port breakout, is configured as a trunk or as a breakout port, is outside the scope of the base network inventory model: the model providing the mapping between the topology and the inventory models should instead provide sufficient information to identify how the port is configured and, in case of breakout configuration, which breakout channel is associated with which Link Termination Point (LTP), abstracting a device physical interface within the topology model.
 
 ## Changes Since RFC 8348
 
@@ -519,7 +527,7 @@ In order to support these use cases, this model is not aligned with {{!RFC8348}}
 
 Instead the name is defined as an optional attribute and the component-id is defined as the key for the component list (in alignment with the approach followed for the network-element list).
 
-{: #ni-augment}
+{:#ni-augment}
 
 # Extending Network Inventory
 
@@ -546,7 +554,7 @@ and other models is illustrated in Figure 4.
 +-------------+    +-------------+     +-------------+   +-------------+
 ~~~~
 
-{: #ni-tree}
+{:#ni-tree}
 
 # Network Inventory Tree Diagram
 
@@ -555,17 +563,17 @@ and other models is illustrated in Figure 4.
 ~~~~ ascii-art
 {::include-fold ./ietf-network-inventory.tree}
 ~~~~
-{: #fig-ni-tree title="Network inventory tree diagram"
+{:#fig-ni-tree title="Network inventory tree diagram"
 artwork-name="ietf-network-inventory.tree"}
 
-{: #ni-yang}
+{:#ni-yang}
 
 # YANG Data Model for Network Inventory
 
 ~~~~ yang
 {::include ./ietf-network-inventory.yang}
 ~~~~
-{: #fig-ni-yang title="Network inventory YANG module"
+{:#fig-ni-yang title="Network inventory YANG module"
 sourcecode-markers="true" sourcecode-name="ietf-network-inventory@2025-02-03.yang"}
 
 # Manageability Considerations
@@ -631,7 +639,7 @@ Openconfig-platform data model is NE-level and uses a generic component concept 
 | backplane                  |                          | Backplane is considered as a part of board. And no need to define as a single component  |
 | software-module            |                          | TBD                      |
 | controller-card            |                          | Controller card is considered as a specific functional board. And no need to define as a single component  |
-{: #tab-oc title="Comparison between openconfig platform and inventory data models"}
+{:#tab-oc title="Comparison between openconfig platform and inventory data models"}
 
 As it mentioned in {{ne-component}} that state data and performance data are out of scope of our data model, it is same for alarm data and it should be defined in some other alarm data models separately. And for some component specific structures in "openconfig-platform", we consider some of them can be contained by our existing structure, such as fan, backplane, and controller-card, while some others do not need to be included in this network inventory model like storage and cpu.
 
@@ -644,7 +652,7 @@ Within this document , with the term "container" we consider an hardware compone
 | terminology of IVY base model  |terminology in other model  |
 | ------------------------------ | -------------------------- |
 | container                      | holder                     |
-{: #tab-term title="terminology mapping"}
+{:#tab-term title="terminology mapping"}
 
 # Efficiency Issue
 
@@ -656,7 +664,7 @@ An alternative YANG model structure, which defines the inventory objects directl
 
 The model proposed by this draft is designed to be as generic as possible so to cover future special types of inventory objects that could be used in other technologies, that have not been identified yet. If the inventory objects were to be defined directly with fixed hierarchical relationships in YANG model, this new type of inventory objects needs to be manually defined, which is not a backward compatible change and therefore is not an acceptable approach for implementation. With a generic model, it is only needed to augment a new component class and extend some specific attributes for this new inventory component class, which is more flexible. We consider that this generic data model, enabling a flexible and backward compatible approach for other technologies, represents the main scope of this draft. Solution description to efficiency/scalability limitations mentioned above is considered as out-of-scope.
 
-# Examples of ports, transceivers and port breakouts {#ports-transceivers-breakouts-examples}
+# Examples of ports, transceivers and port breakouts {#port-examples}
 
 > Editors' Note: Need to provide some examples based on [IETF 121 Slides](https://datatracker.ietf.org/doc/slides-120-ivy-2-a-yang-data-model-for-network-inventory/), and in particular:
 > - slide 8 (100G-LR single-channel port)
@@ -680,7 +688,7 @@ The example instantiates the "ietf-network-inventory" model to describe a single
 
 From a network inventory perspective, there is no need to distinguish between single-channel and MPO trunk-only ports.
 
-Reporting whether an MPO port is configured as a trunk or as a breakout port, is outside the scope of the base network inventory model: the inventory topology mapping should instead provide sufficient information to identify how the MPO port is configured and, in case of breakout configuration, which channel is associated with which Link Termination Point (LTP).
+Note: as described in {{ports}}, reporting whether an MPO port is configured as a trunk or as a breakout port, is outside the scope of the base network inventory model.
 
 ~~~~ ascii-art
 {::include-fold json/ports-transceivers-breakouts-examples.json}

--- a/draft-ietf-ivy-network-inventory-yang.md
+++ b/draft-ietf-ivy-network-inventory-yang.md
@@ -223,7 +223,7 @@ Breakout Port:
 : A port is usually associated with a single physical interface. A breakout port is a port which is broken down and associated into multiple interfaces.
 
 Breakout channel:
-: An abstraction of the atomic elements into which a breakout port can be broken down: an interface can be associated with one or more breakout channels but no more than one interface can be associated with one breakout channel.
+: An abstraction of the atomic resource elements into which a breakout port can be broken down: an interface can be associated with one or more breakout channels but no more than one interface can be associated with one breakout channel.
 : The physical elements abstracted as breakout channels are implementation specific.
 {{ports-transceivers-breakouts-examples}} provides some examples of breakout ports configurations and implementations.
 

--- a/draft-ietf-ivy-network-inventory-yang.md
+++ b/draft-ietf-ivy-network-inventory-yang.md
@@ -211,8 +211,8 @@ The YANG data model defined in this document conforms to the Network Management 
 > Editors' Note: The port definition below needs to be moved to iana-hardware update
 
 Port:
-: An holder for a transceivers module, representing the position of the port within the containing module.
-: In case of pluggable ports, the port may be empty when no transceivers module is plugged in.
+: A component where networking traffic can be received and/or transmitted, e.g., by attaching networking cables.
+: In case of pluggable ports, the port may be empty when no transceiver module is plugged in.
 
   Container:
   : A hardware component class that is capable of containing one or more removable physical entities (e.g., a slot in a chassis is containing a board).
@@ -527,7 +527,7 @@ and other models is illustrated in Figure 4.
 {{fig-ni-tree}} below shows the tree diagram of the YANG data model defined in module "ietf-network-inventory" ({{ni-yang}}).
 
 ~~~~ ascii-art
-{::include ./ietf-network-inventory.tree}
+{::include-fold ./ietf-network-inventory.tree}
 ~~~~
 {: #fig-ni-tree title="Network inventory tree diagram"
 artwork-name="ietf-network-inventory.tree"}

--- a/draft-ietf-ivy-network-inventory-yang.md
+++ b/draft-ietf-ivy-network-inventory-yang.md
@@ -186,6 +186,11 @@ The YANG data model defined in this document conforms to the Network Management 
 
   The terminology for describing YANG data models is found in {{!RFC7950}}.
 
+  The following terms are defined in {{!RFC8343}} and are not redefined
+  here:
+
+  * physical interface
+
   > TBD: Recap the concept of chassis/slot/component/board/... in {{TMF_SD2-20}}.
 
   Also, the document makes use of the following terms:
@@ -214,8 +219,16 @@ Port:
 : A component where networking traffic can be received and/or transmitted, e.g., by attaching networking cables.
 : In case of pluggable ports, the port may be empty when no transceiver module is plugged in.
 
-  Container:
-  : A hardware component class that is capable of containing one or more removable physical entities (e.g., a slot in a chassis is containing a board).
+Breakout Port:
+: A port is usually associated with a single physical interface. A breakout port is a port which is broken down and associated into multiple interfaces.
+
+Breakout channel:
+: An abstraction of the atomic elements into which a breakout port can be broken down: an interface can be associated with one or more breakout channels but no more than one interface can be associated with one breakout channel.
+: The physical elements abstracted as breakout channels are implementation specific.
+{{ports-transceivers-breakouts-examples}} provides some examples of breakout ports configurations and implementations.
+
+Container:
+: A hardware component class that is capable of containing one or more removable physical entities (e.g., a slot in a chassis is containing a board).
 
 Transceiver:
 : A transceiver represents a transmitter/receiver (Tx/Rx) pair which is transmitting and receiving a signal from the media.
@@ -621,6 +634,14 @@ An alternative YANG model structure, which defines the inventory objects directl
 
 The model proposed by this draft is designed to be as generic as possible so to cover future special types of inventory objects that could be used in other technologies, that have not been identified yet. If the inventory objects were to be defined directly with fixed hierarchical relationships in YANG model, this new type of inventory objects needs to be manually defined, which is not a backward compatible change and therefore is not an acceptable approach for implementation. With a generic model, it is only needed to augment a new component class and extend some specific attributes for this new inventory component class, which is more flexible. We consider that this generic data model, enabling a flexible and backward compatible approach for other technologies, represents the main scope of this draft. Solution description to efficiency/scalability limitations mentioned above is considered as out-of-scope.
 
+# Examples of ports, transceivers and port breakouts {#ports-transceivers-breakouts-examples}
+
+> \[Editors' Note]: Need to provide some examples based on [IETF 121 Slides](https://datatracker.ietf.org/doc/slides-120-ivy-2-a-yang-data-model-for-network-inventory/), and in particular:
+> - slide 8 (100G-LR single-channel port)
+> - slide 9 (400G-LR4 multi-channel WDM port)
+> - slide 10 (400G-DR4 MPO port)
+> Describe the concept of host and line channels and the mapping to breakout channels
+
 # JSON Examples
 
 This appendix contains an example of an instance data tree in JSON encoding {{?RFC7951}}.
@@ -629,11 +650,11 @@ The example instantiates the "ietf-network-inventory" model to describe a single
 
 1. An integrated port (non pluggable). This port can be of any type (e.g., optical or electrical), single-channel or multi-channel but not supporting breakouts;
 1. An empty port;
-1. A single channel optical pluggable port ();
+1. A single channel optical pluggable port (e.g., a 100G-LR port configured as a single 100GE interface);
 1. A Wavelength-Division Multiplexing (WDM) based multi-channel optical port (e.g., a 400G-LR4 port configured as a single 400GE interface) which does not support breakouts: the four WDM channels are not reported since not relevant from inventory management perspective;
-1. A Multi-Fiber Push-on (MPO) trunk-only port (e.g., 400G-DR4 port configured as a single 400GE interface). This type of MPO port does not support breakouts: the four WDM channels are not reported since not relevant from inventory management perspective;
-1. An MPO trunk port (e.g., 400G-DR4 port configured as a single 400GE interface). This type of MPO port can support either the trunk or the breakout configuration but in this example, it is configured to support the trunk configuration: the four WDM channels are reported to support breakouts configuration, when needed.
-1. An MPO breakout port (e.g., 400G-DR4 port configured as 4 100GE interfaces): the four WDM channels are reported to support breakouts configuration.
+1. A Multi-Fiber Push-on (MPO) trunk-only port (e.g., 400G-DR4 port configured as a single 400GE interface). This type of MPO port does not support breakouts: the four channels are not reported since not relevant from inventory management perspective;
+1. An MPO trunk port (e.g., 400G-DR4 port configured as a single 400GE interface). This type of MPO port can support either the trunk or the breakout configuration but in this example, it is configured to support the trunk configuration: the four channels are reported to support breakouts configuration, when needed.
+1. An MPO breakout port (e.g., 400G-DR4 port configured as 4x100GE interfaces): the four channels are reported to support breakouts configuration.
 
 From a network inventory perspective, there is no need to distinguish between single-channel and MPO trunk-only ports.
 

--- a/draft-ietf-ivy-network-inventory-yang.md
+++ b/draft-ietf-ivy-network-inventory-yang.md
@@ -194,24 +194,28 @@ The following terms are defined in the description statements of the correspondi
 - stack
 - storage device
 
-> Note that the definition of port component in {{IANA_HW_YANG}} needs to be refined in future version of this document.
+> Editors' Note: The port definition below needs to be moved to iana-hardware update
+
+Port:
+: A component where networking traffic can be received and/or transmitted, e.g., by attaching networking cables.
+: In case of pluggable ports, the port may be empty when no transceiver module is plugged in.
 
 > TBD: Recap the concept of chassis/slot/component/board/... in {{TMF_SD2-20}}.
 
 Also, the document makes use of the following terms:
+
+The following terms are defined in {{!RFC8343}} and are not redefined
+here:
+
+* physical interface
+
+> TBD: Recap the concept of chassis/slot/component/board/... in {{TMF_SD2-20}}.
 
 Network Inventory:
 : A collection of data for network elements and their components managed by a specific management system.
 
 Physical Network Element:
 : An implementation or application specific group of components (e.g., hardware components).
-
-  The following terms are defined in {{!RFC8343}} and are not redefined
-  here:
-
-  * physical interface
-
-  > TBD: Recap the concept of chassis/slot/component/board/... in {{TMF_SD2-20}}.
 
 Network Element:
 : The generalization of the physical network element definition.
@@ -226,15 +230,8 @@ Component:
 Slot:
 : A holder of the board.
 
-
 Board/Card:
 : A pluggable equipment can be inserted into one or several slots (or sub-slots) and can afford a specific transmission function independently.
-
-> Editors' Note: The port definition below needs to be moved to iana-hardware update
-
-Port:
-: A component where networking traffic can be received and/or transmitted, e.g., by attaching networking cables.
-: In case of pluggable ports, the port may be empty when no transceiver module is plugged in.
 
 Breakout Port:
 : A port is usually associated with a single physical interface. A breakout port is a port which is broken down and associated into multiple interfaces.
@@ -561,7 +558,7 @@ artwork-name="ietf-network-inventory.tree"}
 {::include ./ietf-network-inventory.yang}
 ~~~~
 {: #fig-ni-yang title="Network inventory YANG module"
-sourcecode-markers="true" sourcecode-name="ietf-network-inventory@2025-01-30.yang"}
+sourcecode-markers="true" sourcecode-name="ietf-network-inventory@2025-02-03.yang"}
 
 # Manageability Considerations
 

--- a/draft-ietf-ivy-network-inventory-yang.md
+++ b/draft-ietf-ivy-network-inventory-yang.md
@@ -208,11 +208,18 @@ The YANG data model defined in this document conforms to the Network Management 
   Board/Card:
   : A pluggable equipment can be inserted into one or several slots (or sub-slots) and can afford a specific transmission function independently.
 
-  Port:
-  : An interface on a board.
+> Editors' Note: The port definition below needs to be moved to iana-hardware update
+
+Port:
+: An holder for a transceivers module, representing the position of the port within the containing module.
+: In case of pluggable ports, the port may be empty when no transceivers module is plugged in.
 
   Container:
   : A hardware component class that is capable of containing one or more removable physical entities (e.g., a slot in a chassis is containing a board).
+
+Transceiver:
+: A transceiver represents a transmitter/receiver (Tx/Rx) pair which is transmitting and receiving a signal from the media.
+: This definition generalizes the transceiver definition in {{?I-D.ietf-ccamp-optical-impairment-topology-yang}} to model also non optical transceivers (e.g., electrical transceivers).
 
 ## Tree Diagrams
 

--- a/draft-ietf-ivy-network-inventory-yang.md
+++ b/draft-ietf-ivy-network-inventory-yang.md
@@ -629,11 +629,11 @@ The example instantiates the "ietf-network-inventory" model to describe a single
 
 1. An integrated port (non pluggable). This port can be of any type (e.g., optical or electrical), single-channel or multi-channel but not supporting breakouts;
 1. An empty port;
-1. A single channel optical pluggable port;
-1. A Wavelength-Division Multiplexing (WDM) based multi-channel optical port () which does not support breakouts: the four WDM channels are not reported since not relevant from inventory management perspective;
-1. A Multi-Fiber Push-on (MPO) trunk-only port. This type of MPO port does not support breakouts: the four WDM channels are not reported since not relevant from inventory management perspective;
-1. An MPO trunk port. This type of MPO port can support either the trunk or the breakout configuration but in this example, it is configured to support the trunk configuration: the four WDM channels are reported to support breakouts configuration, when needed.
-1. An MPO breakout port: the four WDM channels are reported to support breakouts configuration.
+1. A single channel optical pluggable port ();
+1. A Wavelength-Division Multiplexing (WDM) based multi-channel optical port (e.g., a 400G-LR4 port configured as a single 400GE interface) which does not support breakouts: the four WDM channels are not reported since not relevant from inventory management perspective;
+1. A Multi-Fiber Push-on (MPO) trunk-only port (e.g., 400G-DR4 port configured as a single 400GE interface). This type of MPO port does not support breakouts: the four WDM channels are not reported since not relevant from inventory management perspective;
+1. An MPO trunk port (e.g., 400G-DR4 port configured as a single 400GE interface). This type of MPO port can support either the trunk or the breakout configuration but in this example, it is configured to support the trunk configuration: the four WDM channels are reported to support breakouts configuration, when needed.
+1. An MPO breakout port (e.g., 400G-DR4 port configured as 4 100GE interfaces): the four WDM channels are reported to support breakouts configuration.
 
 From a network inventory perspective, there is no need to distinguish between single-channel and MPO trunk-only ports.
 

--- a/draft-ietf-ivy-network-inventory-yang.md
+++ b/draft-ietf-ivy-network-inventory-yang.md
@@ -204,12 +204,15 @@ Port:
 
 Also, the document makes use of the following terms:
 
-The following terms are defined in {{!RFC8343}} and are not redefined
-here:
+Physical interface:
+: An interface associated to a physical port. A physical interface is always in the lowest layer of the interface stack.
 
-* physical interface
+Logical interface:
+: An interface which is not associated to a physical port.
 
-> TBD: Recap the concept of chassis/slot/component/board/... in {{TMF_SD2-20}}.
+> Editors' Note: check whether the definitions of physical and logical interfaces can be replaced by a normative reference to {{!RFC8343}}
+
+> Editors' Note: Add recap for the concepts of chassis/slot/component/board/... in {{TMF_SD2-20}}.
 
 Network Inventory:
 : A collection of data for network elements and their components managed by a specific management system.
@@ -234,10 +237,15 @@ Board/Card:
 : A pluggable equipment can be inserted into one or several slots (or sub-slots) and can afford a specific transmission function independently.
 
 Breakout Port:
-: A port is usually associated with a single physical interface. A breakout port is a port which is broken down and associated into multiple interfaces.
+: A port is usually associated with a single physical interface. A breakout port is a port which is broken down and associated into multiple physical interfaces.
+
+Port Breakout:
+: The configuration of a breakout port.
+
+> Note that interface channelization, when an interface (e.g., an Ethernet interface) is configured to support multiple logical sub-interfaces (e.g., VLAN interfaces), is different than port breakout and outside the scope of inventory models.
 
 Breakout channel:
-: An abstraction of the atomic resource elements into which a breakout port can be broken down: an interface can be associated with one or more breakout channels but no more than one interface can be associated with one breakout channel.
+: An abstraction of the atomic resource elements into which a breakout port can be broken down: a physical interface can be associated with one or more breakout channels but no more than one physical interface can be associated with one breakout channel.
 : The physical elements abstracted as breakout channels are implementation specific.
 {{ports-transceivers-breakouts-examples}} provides some examples of breakout ports configurations and implementations.
 
@@ -650,7 +658,7 @@ The model proposed by this draft is designed to be as generic as possible so to 
 
 # Examples of ports, transceivers and port breakouts {#ports-transceivers-breakouts-examples}
 
-> \[Editors' Note]: Need to provide some examples based on [IETF 121 Slides](https://datatracker.ietf.org/doc/slides-120-ivy-2-a-yang-data-model-for-network-inventory/), and in particular:
+> Editors' Note: Need to provide some examples based on [IETF 121 Slides](https://datatracker.ietf.org/doc/slides-120-ivy-2-a-yang-data-model-for-network-inventory/), and in particular:
 > - slide 8 (100G-LR single-channel port)
 > - slide 9 (400G-LR4 multi-channel WDM port)
 > - slide 10 (400G-DR4 MPO port)

--- a/ietf-network-inventory.tree
+++ b/ietf-network-inventory.tree
@@ -17,33 +17,33 @@ module: ietf-network-inventory
            +--ro product-name?         string
            +--rw components
               +--rw component* [component-id]
-                 +--rw component-id                         string
-                 +--ro class                                union
-                 +--ro uuid?                                yang:uuid
-                 +--rw name?                                string
-                 +--rw description?                         string
-                 +--rw alias?                               string
-                 +--ro hardware-rev?                        string
-                 +--ro software-rev?                        string
-                 +--ro software-patch-rev*                  string
-                 +--ro mfg-name?                            string
+                 +--rw component-id                        string
+                 +--ro class                               union
+                 +--ro uuid?                               yang:uuid
+                 +--rw name?                               string
+                 +--rw description?                        string
+                 +--rw alias?                              string
+                 +--ro hardware-rev?                       string
+                 +--ro software-rev?                       string
+                 +--ro software-patch-rev*                 string
+                 +--ro mfg-name?                           string
                  +--ro mfg-date?
                  |       yang:date-and-time
-                 +--ro serial-number?                       string
-                 +--ro product-name?                        string
-                 +--ro firmware-rev?                        string
-                 +--ro part-number?                         string
-                 +--ro asset-id?                            string
+                 +--ro serial-number?                      string
+                 +--ro product-name?                       string
+                 +--ro firmware-rev?                       string
+                 +--ro part-number?                        string
+                 +--ro asset-id?                           string
                  +--ro child-component-ref
-                 +--ro parent-rel-pos?                      int32
+                 +--ro parent-rel-pos?                     int32
                  +--ro parent-component-ref
-                 +--ro is-fru?                              boolean
-                 +--ro uri*                                 inet:uri
+                 +--ro is-fru?                             boolean
+                 +--ro uri*                                inet:uri
                  +--ro chassis-specific-info
                  +--ro slot-specific-info
                  +--ro board-specific-info
                  +--ro port-specific-info
-                 +--ro transceivers-module-specific-info
+                 +--ro transceiver-module-specific-info
                     +--ro channels!
                        +--ro channel* [channel-number]
                           +--ro channel-number    uint8

--- a/ietf-network-inventory.tree
+++ b/ietf-network-inventory.tree
@@ -17,28 +17,33 @@ module: ietf-network-inventory
            +--ro product-name?         string
            +--rw components
               +--rw component* [component-id]
-                 +--rw component-id             string
-                 +--ro class                    union
-                 +--ro uuid?                    yang:uuid
-                 +--rw name?                    string
-                 +--rw description?             string
-                 +--rw alias?                   string
-                 +--ro hardware-rev?            string
-                 +--ro software-rev?            string
-                 +--ro software-patch-rev*      string
-                 +--ro mfg-name?                string
-                 +--ro mfg-date?                yang:date-and-time
-                 +--ro serial-number?           string
-                 +--ro product-name?            string
-                 +--ro firmware-rev?            string
-                 +--ro part-number?             string
-                 +--ro asset-id?                string
+                 +--rw component-id                         string
+                 +--ro class                                union
+                 +--ro uuid?                                yang:uuid
+                 +--rw name?                                string
+                 +--rw description?                         string
+                 +--rw alias?                               string
+                 +--ro hardware-rev?                        string
+                 +--ro software-rev?                        string
+                 +--ro software-patch-rev*                  string
+                 +--ro mfg-name?                            string
+                 +--ro mfg-date?
+                 |       yang:date-and-time
+                 +--ro serial-number?                       string
+                 +--ro product-name?                        string
+                 +--ro firmware-rev?                        string
+                 +--ro part-number?                         string
+                 +--ro asset-id?                            string
                  +--ro child-component-ref
-                 +--ro parent-rel-pos?          int32
+                 +--ro parent-rel-pos?                      int32
                  +--ro parent-component-ref
-                 +--ro is-fru?                  boolean
-                 +--ro uri*                     inet:uri
+                 +--ro is-fru?                              boolean
+                 +--ro uri*                                 inet:uri
                  +--ro chassis-specific-info
                  +--ro slot-specific-info
                  +--ro board-specific-info
                  +--ro port-specific-info
+                 +--ro transceivers-module-specific-info
+                    +--ro channels!
+                       +--ro channel* [channel-number]
+                          +--ro channel-number    uint8

--- a/ietf-network-inventory.tree
+++ b/ietf-network-inventory.tree
@@ -44,6 +44,6 @@ module: ietf-network-inventory
                  +--ro board-specific-info
                  +--ro port-specific-info
                  +--ro transceiver-module-specific-info
-                    +--ro channels!
-                       +--ro channel* [channel-number]
-                          +--ro channel-number    uint8
+                    +--ro breakout-channels!
+                       +--ro breakout-channel* [channel-id]
+                          +--ro channel-id    uint8

--- a/ietf-network-inventory.tree
+++ b/ietf-network-inventory.tree
@@ -36,14 +36,10 @@ module: ietf-network-inventory
                  +--ro asset-id?                           string
                  +--ro child-component-ref
                  +--ro parent-rel-pos?                     int32
-                 +--ro parent-component-ref
-                 +--ro is-fru?                             boolean
-                 +--ro uri*                                inet:uri
-                 +--ro parent-rel-pos?          int32
                  +--ro parent?
                  |       -> ../../component/component-id
-                 +--ro is-fru?                  boolean
-                 +--ro uri*                     inet:uri
+                 +--ro is-fru?                             boolean
+                 +--ro uri*                                inet:uri
                  +--ro chassis-specific-info
                  +--ro slot-specific-info
                  +--ro board-specific-info

--- a/ietf-network-inventory.yang
+++ b/ietf-network-inventory.yang
@@ -68,7 +68,7 @@ module ietf-network-inventory {
   // RFC Ed.: update the date below with the date of RFC publication
   // and remove this note.
 
-  revision 2025-01-27 {
+  revision 2025-02-03 {
     description
       "Initial version";
     reference
@@ -159,13 +159,13 @@ module ietf-network-inventory {
   grouping channel-ref {
     description
       "This grouping is intended to be used by data models that need
-      to reference one or more channels within a transceivers module
-      component.";
+       to reference one or more breakout channels within a
+       transceivers module component.";
     leaf ne-ref {
       type nwi:ne-ref;
       description
         "The reference to the Network Element which contains the
-        port to be referenced.";
+         transceiver module to be referenced.";
     }
     leaf transceiver-module-ref {
       type leafref {
@@ -182,18 +182,19 @@ module ietf-network-inventory {
       description
         "The reference to the transceivers module component.";
     }
-    leaf-list channel-number {
+    leaf-list channel-ref {
       type leafref {
         path  "/nwi:network-inventory/nwi:network-elements"
             + "/nwi:network-element[nwi:ne-id=current()/../ne-ref]/"
             + "nwi:components/"
             + "nwi:component[nwi:component-id="
             + "current()/../transceiver-module-ref]/"
-            + "nwi:transceiver-module-specific-info/nwi:channels/"
-            + "nwi:channel/nwi:channel-number";
+            + "nwi:transceiver-module-specific-info/"
+            + "nwi:breakout-channels/nwi:breakout-channel/"
+            + "nwi:channel-id";
       }
       description
-        "The references to the channels.";
+        "The references to the breakout channels.";
     }
   }
 
@@ -523,23 +524,24 @@ module ietf-network-inventory {
               description
                 "This container contains some attributes belong to
                  transceivers modules only.";
-              container channels {
+              container breakout-channels {
                 presence
-                  "When present it represents a multi-channel port
-                   which supports port breakouts.";
+                  "When present it indicates that the multi-channel
+                   port supports port breakouts.";
                 description
-                  "Top level container for the list of channels
-                   supported by the transceivers module.";
-                list channel {
-                  key "channel-number";
-                  leaf channel-number {
+                  "Top level container for the list of breakout
+                   channels supported by the transceivers module.";
+                list breakout-channel {
+                  key "channel-id";
+                  leaf channel-id {
                     type uint8;
                     description
-                      "The channel number uniquely identifying the
-                       channel within the port.";
+                      "An identifier that uniquely identifies the
+                       breakout channel within the transceiver
+                       module.";
                   }
                   description
-                    "The list of channels supported by the
+                    "The list of breakout channels supported by the
                      transceivers module.";
                 }
               }

--- a/ietf-network-inventory.yang
+++ b/ietf-network-inventory.yang
@@ -114,8 +114,89 @@ module ietf-network-inventory {
   }
 
   /*
+   * Types
+   */
+
+  typedef ne-ref {
+    type leafref {
+      path  "/nwi:network-inventory/nwi:network-elements"
+          + "/nwi:network-element/nwi:ne-id";
+    }
+    description
+      "This type is intended to be used by data models that need to
+      reference Network Element.";
+  }
+
+  /*
    * Groupings
    */
+
+  grouping port-ref {
+    description
+      "This grouping is intended to be used by data models that need
+      to reference a port component within a Network Element.";
+    leaf ne-ref {
+      type nwi:ne-ref;
+      description
+        "The reference to the Network Element which contains the
+        port to be referenced.";
+    }
+    leaf port-ref {
+      type leafref {
+        path
+          "/nwi:network-inventory/nwi:network-elements/"
+        + "nwi:network-element[nwi:ne-id=current()/../nwi:ne-ref]"
+        + "/nwi:components/nwi:component/nwi:component-id";
+      }
+      must "derived-from-or-self (/nwi:network-inventory/
+            nwi:network-elements/nwi:network-element
+            [nwi:ne-id=../ne-ref]/nwi:components/nwi:component
+            [nwi:component-id=current()]/nwi:class, 'ianahw:port')";
+      description
+        "The reference to the port component.";
+    }
+  }
+
+  grouping channel-ref {
+    description
+      "This grouping is intended to be used by data models that need
+      to reference one or more channels within a transceivers module
+      component.";
+    leaf ne-ref {
+      type nwi:ne-ref;
+      description
+        "The reference to the Network Element which contains the
+        port to be referenced.";
+    }
+    leaf transceivers-module-ref {
+      type leafref {
+        path
+          "/nwi:network-inventory/nwi:network-elements/"
+        + "nwi:network-element[nwi:ne-id=current()/../nwi:ne-ref]"
+        + "/nwi:components/nwi:component/nwi:component-id";
+      }
+      must "derived-from-or-self (/nwi:network-inventory/
+            nwi:network-elements/nwi:network-element
+            [nwi:ne-id=../ne-ref]/nwi:components/nwi:component
+            [nwi:component-id=current()]/nwi:class,
+            'nwi:transceivers-module')";
+      description
+        "The reference to the transceivers module component.";
+    }
+    leaf-list channel-number {
+      type leafref {
+        path  "/nwi:network-inventory/nwi:network-elements"
+            + "/nwi:network-element[nwi:ne-id=current()/../ne-ref]/"
+            + "nwi:components/"
+            + "nwi:component[nwi:component-id="
+            + "current()/../transceivers-module-ref]/"
+            + "nwi:transceivers-module-specific-info/nwi:channels/"
+            + "nwi:channel/nwi:channel-number";
+      }
+      description
+        "The references to the channels.";
+    }
+  }
 
   grouping common-entity-attributes {
     description

--- a/ietf-network-inventory.yang
+++ b/ietf-network-inventory.yang
@@ -68,7 +68,7 @@ module ietf-network-inventory {
   // RFC Ed.: update the date below with the date of RFC publication
   // and remove this note.
 
-  revision 2024-10-02 {
+  revision 2024-12-11 {
     description
       "Initial version";
     reference
@@ -97,8 +97,101 @@ module ietf-network-inventory {
     }
 
   /*
+   * Editors' Note: This identity may need to be moved to
+   *                iana-hardware update
+   */
+
+  identity transceivers-module {
+    base ianahw:hardware-class;
+    description
+      "This identity is applicable if the hardware class is some sort
+       of self-contained sub-system which contains one or more
+       transceivers (e.g., optical or electrical transceivers) which
+       are transmitting and receiving a signal from the media.
+       
+       A transceivers-module component can only be contained by a
+       port component.";
+  }
+
+  /*
+   * Types
+   */
+
+
+  typedef ne-ref {
+    type leafref {
+      path  "/nwi:network-inventory/nwi:network-elements"
+          + "/nwi:network-element/nwi:ne-id";
+    }
+    description
+      "This type is intended to be used by data models that need to
+      reference Network Element.";
+  }
+
+  /*
    * Groupings
    */
+
+  grouping port-ref {
+    description
+      "This grouping is intended to be used by data models that need
+      to reference a port component within a Network Element.";
+    leaf ne-ref {
+      type nwi:ne-ref;
+      description
+        "The reference to the Network Element which contains the
+        port to be referenced.";
+    }
+    leaf port-ref {
+      type leafref {
+        path  "/nwi:network-inventory/nwi:network-elements"
+            + "/nwi:network-element[nwi:ne-id=current()/../ne-ref]/"
+            + "nwi:components/nwi:component/nwi:component-id";
+      }
+      must  "derived-from-or-self (/nwi:network-inventory/"
+          + "nwi:network-elements/nwi:network-element[nwi:ne-id="
+          + "current()/../ne-ref]/nwi:components/"
+          + "nwi:component[nwi:component-id=current()]/nwi:/class,"
+          + "'ianahw:port')";
+      description
+        "The reference to the port component.";
+    }
+  }
+
+  grouping channel-ref {
+    description
+      "This grouping is intended to be used by data models that need
+      to reference one or more channels within a transceivers module
+      component.";
+    leaf ne-ref {
+      type nwi:ne-ref;
+      description
+        "The reference to the Network Element which contains the
+        port to be referenced.";
+    }
+    leaf transceivers-module-ref {
+      type leafref {
+        path  "/nwi:network-inventory/nwi:network-elements"
+            + "/nwi:network-element[nwi:ne-id=current()/../ne-ref]/"
+            + "nwi:components/nwi:component/nwi:component-id";
+      }
+      description
+        "The reference to the transceivers module component.";
+    }
+    leaf-list channel-number {
+      type leafref {
+        path  "/nwi:network-inventory/nwi:network-elements"
+            + "/nwi:network-element[nwi:ne-id=current()/../ne-ref]/"
+            + "nwi:components/"
+            + "nwi:component[nwi:component-id="
+            + "current()/../transceivers-module-ref]/"
+            + "nwi:transceivers-module-specific-info/nwi:channels/"
+            + "nwi:channel/nwi:channel-number";
+      }
+      description
+        "The references to the channels.";
+    }
+  }
 
   grouping common-entity-attributes {
     description
@@ -412,6 +505,34 @@ module ietf-network-inventory {
               description
                 "This container contains some attributes belong to
                 port only.";
+            }
+            container transceivers-module-specific-info {
+              when "derived-from-or-self(../class, 
+                    'nwi:transceivers-module')";
+              config false;
+              description
+                "This container contains some attributes belong to
+                transceivers modules only.";
+              container channels {
+                presence
+                  "When present it represents a multi-channel port
+                   which supports port breakouts.";
+                description
+                  "Top level container for the list of channels
+                   supported by the transceivers module.";
+                list channel {
+                  key channel-number;
+                  leaf channel-number {
+                    type uint8;
+                    description
+                      "The channel number uniquely identifying the
+                      channel within the port.";
+                  }
+                  description
+                    "The list of channels supported by the
+                     transceivers module.";
+                }
+              }
             }
           }
         }

--- a/ietf-network-inventory.yang
+++ b/ietf-network-inventory.yang
@@ -90,11 +90,11 @@ module ietf-network-inventory {
       "Base identity for Network Element (NE) types.";
   }
 
-    identity ne-physical {
-      base nwi:ne-type;
-      description
-        "A physical network element (NE). ";
-    }
+  identity ne-physical {
+    base nwi:ne-type;
+    description
+      "A physical network element (NE). ";
+  }
 
   /*
    * Editors' Note: This identity may need to be moved to
@@ -108,7 +108,7 @@ module ietf-network-inventory {
        of self-contained sub-system which contains one or more
        transceivers (e.g., optical or electrical transceivers) which
        are transmitting and receiving a signal from the media.
-       
+
        A transceivers-module component can only be contained by a
        port component.";
   }
@@ -265,48 +265,48 @@ module ietf-network-inventory {
                 "The type of the component.";
             }
             uses common-entity-attributes {
-              refine hardware-rev {
+              refine "hardware-rev" {
                 description
                   "The vendor-specific hardware revision string for
-                  the component. The preferred value is the hardware
-                  revision identifier actually printed on the
-                  component itself (if present).";
+                   the component. The preferred value is the hardware
+                   revision identifier actually printed on the
+                   component itself (if present).";
                 reference
                   "RFC 6933: Entity MIB (Version 4) -
-                            entPhysicalHardwareRev";
+                             entPhysicalHardwareRev";
               }
-              refine software-rev {
+              refine "software-rev" {
                 reference
                   "RFC 6933: Entity MIB (Version 4) -
-                            entPhysicalSoftwareRev";
+                             entPhysicalSoftwareRev";
               }
-              refine mfg-name {
+              refine "mfg-name" {
                 description
                   "The name of the manufacturer of this physical
-                  component.
-                  The preferred value is the manufacturer name string
-                  actually printed on the component itself
-                  (if present).
+                   component.
+                   The preferred value is the manufacturer name
+                   string actually printed on the component itself
+                   (if present).
 
-                  Note that comparisons between instances of the
-                  'model-name', 'firmware-rev', 'software-rev', and
-                  'serial-number' nodes are only meaningful amongst
-                  components with the same value of 'mfg-name'.
+                   Note that comparisons between instances of the
+                   'model-name', 'firmware-rev', 'software-rev', and
+                   'serial-number' nodes are only meaningful amongst
+                   components with the same value of 'mfg-name'.
 
-                  If the manufacturer name string associated with the
-                  physical component is unknown to the server, then
-                  this node is not instantiated.";
+                   If the manufacturer name string associated with
+                   the physical component is unknown to the server,
+                   then this node is not instantiated.";
                 reference
                   "RFC 6933: Entity MIB (Version 4) -
-                  entPhysicalMfgName";
+                             entPhysicalMfgName";
               }
-              refine mfg-date {
+              refine "mfg-date" {
                 description
                   "The date of manufacturing of the managed
-                  component.";
+                   component.";
                 reference
                   "RFC 6933: Entity MIB (Version 4) -
-                  entPhysicalMfgDate";
+                             entPhysicalMfgDate";
               }
             }
             leaf firmware-rev {
@@ -340,7 +340,7 @@ module ietf-network-inventory {
                  implementation needs to use some mechanism to handle
                  the differences in size and characters allowed
                  between this leaf and entPhysicalAssetID.
-                 
+
                  The definition of such a mechanism is outside the
                  scope of this document.";
               reference
@@ -365,7 +365,7 @@ module ietf-network-inventory {
                  component among all the sibling components.";
               reference
                 "RFC 6933: Entity MIB (Version 4) -
-                          entPhysicalParentRelPos";
+                           entPhysicalParentRelPos";
             }
             container parent-component-ref {
               config false;
@@ -401,42 +401,48 @@ module ietf-network-inventory {
                 "RFC 6933: Entity MIB (Version 4) - entPhysicalUris";
             }
             container chassis-specific-info {
-              when "derived-from-or-self(../class, 
-                    'ianahw:chassis')";
+              when
+                "derived-from-or-self(../nwi:class,
+                'ianahw:chassis')";
               config false;
               description
                 "This container contains some attributes belong to
-                chassis only.";
+                 chassis only.";
             }
             container slot-specific-info {
-              when "derived-from-or-self(../class,
-                    'ianahw:container')";
+              when
+                "derived-from-or-self(../nwi:class,
+                'ianahw:container')";
               config false;
               description
                 "This container contains some attributes belong to
-                slot only.";
+                 slot only.";
             }
             container board-specific-info {
-              when "derived-from-or-self(../class, 'ianahw:module')";
+              when
+                "derived-from-or-self(../nwi:class,
+                'ianahw:module')";
               config false;
               description
                 "This container contains some attributes belong to
-                board only.";
+                 board only.";
             }
             container port-specific-info {
-              when "derived-from-or-self(../class, 'ianahw:port')";
+              when
+                "derived-from-or-self(../nwi:class, 'ianahw:port')";
               config false;
               description
                 "This container contains some attributes belong to
-                port only.";
+                 port only.";
             }
             container transceivers-module-specific-info {
-              when "derived-from-or-self(../class, 
-                    'nwi:transceivers-module')";
+              when
+                "derived-from-or-self(../nwi:class,
+                'nwi:transceivers-module')";
               config false;
               description
                 "This container contains some attributes belong to
-                transceivers modules only.";
+                 transceivers modules only.";
               container channels {
                 presence
                   "When present it represents a multi-channel port
@@ -445,12 +451,12 @@ module ietf-network-inventory {
                   "Top level container for the list of channels
                    supported by the transceivers module.";
                 list channel {
-                  key channel-number;
+                  key "channel-number";
                   leaf channel-number {
                     type uint8;
                     description
                       "The channel number uniquely identifying the
-                      channel within the port.";
+                       channel within the port.";
                   }
                   description
                     "The list of channels supported by the

--- a/ietf-network-inventory.yang
+++ b/ietf-network-inventory.yang
@@ -68,7 +68,7 @@ module ietf-network-inventory {
   // RFC Ed.: update the date below with the date of RFC publication
   // and remove this note.
 
-  revision 2024-12-11 {
+  revision 2024-12-16 {
     description
       "Initial version";
     reference
@@ -114,84 +114,8 @@ module ietf-network-inventory {
   }
 
   /*
-   * Types
-   */
-
-
-  typedef ne-ref {
-    type leafref {
-      path  "/nwi:network-inventory/nwi:network-elements"
-          + "/nwi:network-element/nwi:ne-id";
-    }
-    description
-      "This type is intended to be used by data models that need to
-      reference Network Element.";
-  }
-
-  /*
    * Groupings
    */
-
-  grouping port-ref {
-    description
-      "This grouping is intended to be used by data models that need
-      to reference a port component within a Network Element.";
-    leaf ne-ref {
-      type nwi:ne-ref;
-      description
-        "The reference to the Network Element which contains the
-        port to be referenced.";
-    }
-    leaf port-ref {
-      type leafref {
-        path  "/nwi:network-inventory/nwi:network-elements"
-            + "/nwi:network-element[nwi:ne-id=current()/../ne-ref]/"
-            + "nwi:components/nwi:component/nwi:component-id";
-      }
-      must  "derived-from-or-self (/nwi:network-inventory/"
-          + "nwi:network-elements/nwi:network-element[nwi:ne-id="
-          + "current()/../ne-ref]/nwi:components/"
-          + "nwi:component[nwi:component-id=current()]/nwi:/class,"
-          + "'ianahw:port')";
-      description
-        "The reference to the port component.";
-    }
-  }
-
-  grouping channel-ref {
-    description
-      "This grouping is intended to be used by data models that need
-      to reference one or more channels within a transceivers module
-      component.";
-    leaf ne-ref {
-      type nwi:ne-ref;
-      description
-        "The reference to the Network Element which contains the
-        port to be referenced.";
-    }
-    leaf transceivers-module-ref {
-      type leafref {
-        path  "/nwi:network-inventory/nwi:network-elements"
-            + "/nwi:network-element[nwi:ne-id=current()/../ne-ref]/"
-            + "nwi:components/nwi:component/nwi:component-id";
-      }
-      description
-        "The reference to the transceivers module component.";
-    }
-    leaf-list channel-number {
-      type leafref {
-        path  "/nwi:network-inventory/nwi:network-elements"
-            + "/nwi:network-element[nwi:ne-id=current()/../ne-ref]/"
-            + "nwi:components/"
-            + "nwi:component[nwi:component-id="
-            + "current()/../transceivers-module-ref]/"
-            + "nwi:transceivers-module-specific-info/nwi:channels/"
-            + "nwi:channel/nwi:channel-number";
-      }
-      description
-        "The references to the channels.";
-    }
-  }
 
   grouping common-entity-attributes {
     description

--- a/ietf-network-inventory.yang
+++ b/ietf-network-inventory.yang
@@ -542,8 +542,8 @@ module ietf-network-inventory {
                  transceivers modules only.";
               container breakout-channels {
                 presence
-                  "When present it indicates that the multi-channel
-                   port supports port breakouts.";
+                  "When present, it indicates that port breakout is
+                   supported.";
                 description
                   "Top level container for the list of breakout
                    channels supported by the transceivers module.";

--- a/ietf-network-inventory.yang
+++ b/ietf-network-inventory.yang
@@ -46,7 +46,7 @@ module ietf-network-inventory {
      The model fully conforms to the Network Management
      Datastore Architecture (NMDA).
 
-     Copyright (c) 2024 IETF Trust and the persons
+     Copyright (c) 2025 IETF Trust and the persons
      identified as authors of the code.  All rights reserved.
 
      Redistribution and use in source and binary forms, with or
@@ -68,7 +68,7 @@ module ietf-network-inventory {
   // RFC Ed.: update the date below with the date of RFC publication
   // and remove this note.
 
-  revision 2024-12-16 {
+  revision 2025-01-27 {
     description
       "Initial version";
     reference
@@ -101,15 +101,14 @@ module ietf-network-inventory {
    *                iana-hardware update
    */
 
-  identity transceivers-module {
+  identity transceiver-module {
     base ianahw:hardware-class;
     description
       "This identity is applicable if the hardware class is some sort
        of self-contained sub-system which contains one or more
-       transceivers (e.g., optical or electrical transceivers) which
-       are transmitting and receiving a signal from the media.
+       transceivers (e.g., optical or electrical transceivers).
 
-       A transceivers-module component can only be contained by a
+       A transceiver-module component can only be contained by a
        port component.";
   }
 
@@ -168,7 +167,7 @@ module ietf-network-inventory {
         "The reference to the Network Element which contains the
         port to be referenced.";
     }
-    leaf transceivers-module-ref {
+    leaf transceiver-module-ref {
       type leafref {
         path
           "/nwi:network-inventory/nwi:network-elements/"
@@ -179,7 +178,7 @@ module ietf-network-inventory {
             nwi:network-elements/nwi:network-element
             [nwi:ne-id=../ne-ref]/nwi:components/nwi:component
             [nwi:component-id=current()]/nwi:class,
-            'nwi:transceivers-module')";
+            'nwi:transceiver-module')";
       description
         "The reference to the transceivers module component.";
     }
@@ -189,8 +188,8 @@ module ietf-network-inventory {
             + "/nwi:network-element[nwi:ne-id=current()/../ne-ref]/"
             + "nwi:components/"
             + "nwi:component[nwi:component-id="
-            + "current()/../transceivers-module-ref]/"
-            + "nwi:transceivers-module-specific-info/nwi:channels/"
+            + "current()/../transceiver-module-ref]/"
+            + "nwi:transceiver-module-specific-info/nwi:channels/"
             + "nwi:channel/nwi:channel-number";
       }
       description
@@ -516,10 +515,10 @@ module ietf-network-inventory {
                 "This container contains some attributes belong to
                  port only.";
             }
-            container transceivers-module-specific-info {
+            container transceiver-module-specific-info {
               when
                 "derived-from-or-self(../nwi:class,
-                'nwi:transceivers-module')";
+                'nwi:transceiver-module')";
               config false;
               description
                 "This container contains some attributes belong to

--- a/json/ports-transceivers-breakouts-examples.json
+++ b/json/ports-transceivers-breakouts-examples.json
@@ -1,0 +1,148 @@
+{
+  "ietf-network-inventory:network-inventory": {
+    "network-elements": {
+      "network-element" : [
+        {
+          "ne-id": "NE-1",
+          "description": "Network element example with ports and breakouts.",
+          "components": {
+            "component": [
+              {
+                "component-id": "board-1",
+                "class": "iana-hardware:module",
+                "description": "Network element example with ports and breakouts."
+              },
+              {
+                "component-id": "port-1",
+                "class": "iana-hardware:port",
+                "description": "Example of an integrated (non-pluggable) port.",
+                "parent-component-ref": "board-1",
+                "parent-rel-pos": 1
+              },
+              {
+                "component-id": "transceivers-module-1",
+                "class": "ietf-network-inventory:transceivers-module",
+                "description": "Example of an integrated (non-pluggable) port.",
+                "parent-component-ref": "port-1",
+                "is-fru": false
+              },
+              {
+                "component-id": "port-2",
+                "class": "iana-hardware:port",
+                "description": "Example of an empty port.",
+                "parent-component-ref": "board-1",
+                "parent-rel-pos": 2
+              },
+              {
+                "component-id": "port-3",
+                "class": "iana-hardware:port",
+                "description": "Example of a single channel optical pluggable port.",
+                "parent-component-ref": "board-1",
+                "parent-rel-pos": 3
+              },
+              {
+                "component-id": "transceivers-module-3",
+                "class": "ietf-network-inventory:transceivers-module",
+                "description": "Example of a single channel optical pluggable port.",
+                "parent-component-ref": "port-3",
+                "is-fru": true
+              },
+              {
+                "component-id": "port-4",
+                "class": "iana-hardware:port",
+                "description": "Example of a WDM multi-channel pluggable port.",
+                "parent-component-ref": "board-1",
+                "parent-rel-pos": 4
+              },
+              {
+                "component-id": "transceivers-module-4",
+                "class": "ietf-network-inventory:transceivers-module",
+                "description": "Example of a WDM multi-channel pluggable port.",
+                "parent-component-ref": "port-4",
+                "is-fru": true
+              },
+              {
+                "component-id": "port-5",
+                "class": "iana-hardware:port",
+                "description": "Example of an optical MPO pluggable trunk port (not supporting breakouts).",
+                "parent-component-ref": "board-1",
+                "parent-rel-pos": 5
+              },
+              {
+                "component-id": "transceivers-module-5",
+                "class": "ietf-network-inventory:transceivers-module",
+                "description": "Example of an optical MPO pluggable trunk port (not supporting breakouts).",
+                "parent-component-ref": "port-5",
+                "is-fru": true
+              },
+              {
+                "component-id": "port-6",
+                "class": "iana-hardware:port",
+                "description": "Example of an optical MPO pluggable trunk port (supporting breakouts).",
+                "parent-component-ref": "board-1",
+                "parent-rel-pos": 6
+              },
+              {
+                "component-id": "transceivers-module-6",
+                "class": "ietf-network-inventory:transceivers-module",
+                "description": "Example of an optical MPO pluggable trunk port (supporting breakouts).",
+                "parent-component-ref": "port-6",
+                "is-fru": true,
+                "transceivers-module-specific-info": {
+                  "channels": {
+                    "channel": [
+                      {
+                        "channel-number": 1
+                      },
+                      {
+                        "channel-number": 2
+                      },
+                      {
+                        "channel-number": 3
+                      },
+                      {
+                        "channel-number": 4
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "component-id": "port-7",
+                "class": "iana-hardware:port",
+                "description": "Example of an optical MPO pluggable breakout port.",
+                "parent-component-ref": "board-1",
+                "parent-rel-pos": 7
+              },
+              {
+                "component-id": "transceivers-module-7",
+                "class": "ietf-network-inventory:transceivers-module",
+                "description": "Example of an optical MPO pluggable breakout port.",
+                "parent-component-ref": "port-7",
+                "is-fru": true,
+                "transceivers-module-specific-info": {
+                  "channels": {
+                    "channel": [
+                      {
+                        "channel-number": 1
+                      },
+                      {
+                        "channel-number": 2
+                      },
+                      {
+                        "channel-number": 3
+                      },
+                      {
+                        "channel-number": 4
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Proposal for ports and breakouts modelling: fix #45 , fix #12 and fix #19

Added references to network-element, port component and channel: fix #69 

Clarified further the applicability of the base model: fix #88

---

In order to validate the JSON examples, some fixes are needed on the YANG file:

1. the parent-component-ref should be defined as a leafref: see PR #66 
2. the component class type should be an identityref and not a union of identityrefs: see issue #78

---

Co-Authored-By: YuChaode <yuchaode@huawei.com>
