### PR TITLE
Add reference to components

### DIFF
--- a/draft-ietf-ivy-network-inventory-yang.md
+++ b/draft-ietf-ivy-network-inventory-yang.md
@@ -146,7 +146,7 @@ of using vendors' proprietary APIs.
 
 Per the definition of {{?RFC8309}} and {{?RFC8969}}, the YANG data model defined in {{!RFC8348}} is a device model while the YANG data model defined in this document is a network model.
 
-As outlined in {{operational}}, the network inventory provides a read-only perspective of the actual inventory data that a network controller knows of what it is actually installed within the network. Therefore other inventory data (e.g., spare or inactive assets) are outside the scope of this model
+As outlined in {{operational}}, the network inventory provides a read-only perspective of the actual inventory data that a network controller knows of what it is actually installed within the network. Therefore, other inventory data (e.g., spare or inactive assets) are outside the scope of this model.
 
 As outlined in {{overview}}, the base inventory YANG data model defined in this document supports only physical network elements but generalizes the network element definition to allow supporting other types of network elements through proper augmentations.
 
@@ -465,7 +465,7 @@ This document re-defines some attributes listed in {{!RFC8348}}, based on some i
 
 ### Part Number
 
-According to the description in {{!RFC8348}}, the attribute named "model-name" under the component, is preferred to have a customer-visible part number value. "Model-name" is not straightforward to understand and therefore in this model the attribute is called "part-number".
+According to the description in {{!RFC8348}}, the attribute named "model-name" under the component, is preferred to have a customer-visible part number value. "Model-name" is not straightforward to understand, and therefore, in this model the attribute is called "part-number".
 
 ### Component identifiers
 
@@ -636,7 +636,7 @@ Mostly, our inventory data model can cover the attributes from OpenConfig.
 
 # Terminology of Container
 
-Within this document , with the term "container" we consider an hardware component class capable of containing one or more removable physical entities, e.g. a slot in a chassis is containing a board.
+Within this document , with the term "container" we consider a hardware component class capable of containing one or more removable physical entities, e.g. a slot in a chassis is containing a board.
 
 | terminology of IVY base model  |terminology in other model  |
 | ------------------------------ | -------------------------- |

--- a/draft-ietf-ivy-network-inventory-yang.md
+++ b/draft-ietf-ivy-network-inventory-yang.md
@@ -171,7 +171,7 @@ summarizes all of the substitutions that are needed.
 Please apply the following replacements:
 
 - XXXX --> the assigned RFC number for this I-D
-- 2026-01-27 --> the actual date of the publication of this document
+- 2026-04-22 --> the actual date of the publication of this document
 
 # Terminology and Notations
 
@@ -499,7 +499,7 @@ artwork-name="ietf-network-inventory.tree"}
 {::include yang/ietf-network-inventory.yang}
 ~~~~
 {:#fig-ni-yang title="Network inventory YANG module"
-sourcecode-markers="true" sourcecode-name="ietf-network-inventory@2026-01-27.yang"}
+sourcecode-markers="true" sourcecode-name="ietf-network-inventory@2026-04-22.yang"}
 
 # Operational Considerations {#operational}
 

--- a/yang/ietf-network-inventory.yang
+++ b/yang/ietf-network-inventory.yang
@@ -120,7 +120,7 @@ module ietf-network-inventory {
       type nwi:ne-ref;
       description
         "The reference to the Network Element which contains the
-         port to be referenced.";
+         component to be referenced.";
     }
     leaf component-ref {
       type leafref {

--- a/yang/ietf-network-inventory.yang
+++ b/yang/ietf-network-inventory.yang
@@ -65,7 +65,7 @@ module ietf-network-inventory {
      described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
      they appear in all capitals, as shown here.";
 
-  revision 2026-04-17 {
+  revision 2026-04-22 {
     description
       "Initial version";
     reference
@@ -110,6 +110,27 @@ module ietf-network-inventory {
   /*
    * Groupings
    */
+
+  grouping component-ref {
+    description
+      "This grouping is intended to be used by data models that need
+       to reference a component within a Network Element.";
+    leaf ne-ref {
+      type nwi:ne-ref;
+      description
+        "The reference to the Network Element which contains the
+         port to be referenced.";
+    }
+    leaf component-ref {
+      type leafref {
+        path "/nwi:network-inventory/nwi:network-elements/"
+           + "nwi:network-element[nwi:ne-id=current()/../ne-ref]"
+           + "/nwi:components/nwi:component/nwi:component-id";
+      }
+      description
+        "The reference to the component.";
+    }
+  }
 
   grouping port-ref {
     description

--- a/yang/ietf-network-inventory.yang
+++ b/yang/ietf-network-inventory.yang
@@ -101,6 +101,7 @@ module ietf-network-inventory {
     type leafref {
       path "/nwi:network-inventory/nwi:network-elements"
          + "/nwi:network-element/nwi:ne-id";
+      require-instance false;
     }
     description
       "This type is intended to be used by data models that need to
@@ -126,6 +127,7 @@ module ietf-network-inventory {
         path "/nwi:network-inventory/nwi:network-elements/"
            + "nwi:network-element[nwi:ne-id=current()/../ne-ref]"
            + "/nwi:components/nwi:component/nwi:component-id";
+        require-instance false;
       }
       description
         "The reference to the component.";
@@ -147,11 +149,8 @@ module ietf-network-inventory {
         path "/nwi:network-inventory/nwi:network-elements/"
            + "nwi:network-element[nwi:ne-id=current()/../ne-ref]"
            + "/nwi:components/nwi:component/nwi:component-id";
+        require-instance false;
       }
-      must "derived-from-or-self (/nwi:network-inventory/
-            nwi:network-elements/nwi:network-element
-            [nwi:ne-id=../ne-ref]/nwi:components/nwi:component
-            [nwi:component-id=current()]/nwi:class, 'ianahw:port')";
       description
         "The reference to the port component.";
     }

--- a/yang/ietf-network-inventory.yang
+++ b/yang/ietf-network-inventory.yang
@@ -152,7 +152,10 @@ module ietf-network-inventory {
         require-instance false;
       }
       description
-        "The reference to the port component.";
+        "The reference to the port component.
+
+         Note: the class of the referenced port component MUST be
+         'ianahw:port' or a derived identity.";
     }
   }
 


### PR DESCRIPTION
Add component-ref grouping, see: https://mailarchive.ietf.org/arch/msg/ivy/Dw7KUFDfz0hMPII-V9VHnMXFzts/

Removed `must` statement from the `port-ref` and added `require-instance false` statement to the `ne-ref`, `port-ref` and `component-ref` leafref data types

Fix some other nits not addressed in PR #161 